### PR TITLE
Two new options introduced: --gitproto and --gitoptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,21 @@ Usage
 Options:
 ---
 ```bash
-  -p, --perpage NUMBER number of repos per page (Default is 100)
-  -t, --type STRING    can be one of: all, public, private, forks, sources,
+  -p,  --perpage NUMBER number of repos per page (Default is 100)
+  -t,  --type STRING    can be one of: all, public, private, forks, sources,
                          member  (Default is all)
-  -e, --exclude STRING   Exclude passed repos, comma separated
-  -o, --only STRING      Only clone passed repos, comma separated
-  -r, --regexp BOOLEAN   If true, exclude or only option will be evaluated as a
+  -e,  --exclude STRING   Exclude passed repos, comma separated
+  -o,  --only STRING      Only clone passed repos, comma separated
+  -r,  --regexp BOOLEAN   If true, exclude or only option will be evaluated as a
                          regexp
-  -u, --username STRING  Username for basic authentication. Required to
+  -u,  --username STRING  Username for basic authentication. Required to
                          access github api
-      --token STRING     Token authentication. Required to access github api
-      --debug            Show debug information
-  -v, --version          Display the current version
-  -h, --help             Display help and usage details
+       --token STRING     Token authentication. Required to access github api
+  -gp, --gitproto         Protocol to use in `git clone` command. Can be `ssh` (default), `https` or `git`
+  -go, --gitoptions       Additional parameters to pass to git clone command. Defaults to empty.
+       --debug            Show debug information
+  -v,  --version          Display the current version
+  -h,  --help             Display help and usage details
 ```
 
 Examples:
@@ -49,12 +51,13 @@ clones all github/twitter repositories, with HTTP basic authentication. A passwo
 
 ```bash
 cloneorg twitter -u GITHUB_USERNAME
+cloneorg twitter --username=GITHUB_USERNAME
 ```
 
 clones all github/twitter repositories, with an access token provided by Github
 
 ```bash
-cloneorg twitter -t GITHUB_TOKEN
+cloneorg twitter --token GITHUB_TOKEN
 ```
 
 If an environment variable `GITHUB_TOKEN` is set, it will be used.
@@ -66,7 +69,7 @@ export GITHUB_TOKEN='YOUR_GITHUB_API_TOKEN'
 Add a -p or --perpage option to paginate response
 
 ```bash
-cloneorg mozilla -t GITHUB_TOKEN -p 10
+cloneorg mozilla --token=GITHUB_TOKEN -p 10
 ```
 
 Exclude and Only options
@@ -75,33 +78,42 @@ Exclude and Only options
 If you only need some repositories, you can pass -o or --only with their names
 
 ```bash
-cloneorg angular -t GITHUB_TOKEN -o angular
+cloneorg angular --token=GITHUB_TOKEN -o angular
 ```
 
 This can be an array to
 
 ```bash
-cloneorg angular -t GITHUB_TOKEN -o angular,material,bower-angular-i18n
+cloneorg angular --token=GITHUB_TOKEN -o angular,material,bower-angular-i18n
 ```
 
 This can also be an regular expression, with -r or --regexp option set to true.
 
 ```bash
-cloneorg marionettejs -t GITHUB_TOKEN -o ^backbone -r true
+cloneorg marionettejs --token=GITHUB_TOKEN -o ^backbone -r true
 ```
 
 The same rules apply to exclude options
 
 ```bash
-cloneorg jquery -t GITHUB_TOKEN -e css-framework # simple
+cloneorg jquery --token=GITHUB_TOKEN -e css-framework # simple
 ```
 
 ```bash
-cloneorg emberjs -t GITHUB_TOKEN -e website,examples # array
+cloneorg emberjs --token=GITHUB_TOKEN -e website,examples # array
 ```
 
 ```bash
-cloneorg gruntjs -t GITHUB_TOKEN -e $-docs -r true # regexp
+cloneorg gruntjs --token=GITHUB_TOKEN -e $-docs -r true # regexp
+```
+
+```bash
+cloneorg gruntjs --token=GITHUB_TOKEN -e $-docs -r true --gitproto=git # Clone using git protocol
+```
+
+```bash
+# Clone using git protocol and pass --recurse to `git clone` to clone submodules also
+cloneorg gruntjs --token=GITHUB_TOKEN -e $-docs -r true --gitproto=git --gitoptions="--recurse"
 ```
 
 ToDo

--- a/index.js
+++ b/index.js
@@ -14,7 +14,9 @@ cli.parse({
     only: ['o', 'Only clone passed repos, comma separated', 'string'],
     regexp: ['r', 'If true, exclude or only option will be evaluated as a regexp', 'boolean', false],
     username: ['u', 'Username for basic authentication. Required to access github api', 'string'],
-    token: ['token', 'Token authentication. Required to access github api', 'string']
+    token: ['token', 'Token authentication. Required to access github api', 'string'],
+    gitproto: ['gp', 'GitHub access protocol: git, ssh or https', 'string', 'ssh'],
+    gitoptions: ['go', 'Additional git options to pass to git clone command', 'string', '']
 });
 
 getRepositories = function(args, options) {

--- a/lib/github.js
+++ b/lib/github.js
@@ -13,6 +13,8 @@ function Organization(options) {
     this.password = options.password;
     this.token = options.token;
     this.regexp = options.regexp;
+    this.gitproto = options.gitproto;
+    this.gitoptions = options.gitoptions;
 
     if (options.only && options.regexp) {
         this.only = new RegExp(options.only);
@@ -117,9 +119,25 @@ Organization.prototype.clone = function(repo) {
 }
 
 Organization.prototype.executeCloneCommand = function(repo) {
-    cli.info('cloning ' + repo.ssh_url);
+    var repo_url;
+    switch (this.gitproto) {
+        case 'ssh':
+            repo_url = repo.ssh_url;
+            break;
+        case 'git':
+            repo_url = repo.git_url;
+            break;
+        case 'https':
+            repo_url = repo.clone_url;
+            break;
+        default:
+            return cli.error ( 'Unknown git access protocol provided: ' + this.gitproto );
+    }
 
-    var process = spawn('git', ['clone', repo.ssh_url]);
+    var spawn_params = [ 'clone' ].concat( this.gitoptions || [], repo_url );
+    cli.info('cloning ' + repo_url);
+
+    var process = spawn('git', spawn_params);
 
     process.on('close', function(status) {
         if (status == 0) {


### PR DESCRIPTION
With this PR two new command line options introduced:
- --gitproto allows you to select protocol to use for gitclone (ssh, https, or git)
- --gitoptions allows you to pass additional options for `git clone` (--recursive for example)
