### PR TITLE
API domain can be configured

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -5,7 +5,6 @@ var spawn = require('child_process').spawn
 var github = exports;
 
 function Organization(options) {
-    this.BASE_URI = 'https://api.github.com/orgs/';
     this.currentPage = 1;
     this.organization = options.organization;
     this.perpage = parseInt(options.perpage);
@@ -31,6 +30,10 @@ function Organization(options) {
     this.type = options.type;
     this.nextPageUrl = this.getRequestUri();
 }
+
+Organization.prototype.BASE_URI = (function(){
+  return process.env.ENTERPRISE_DOMAIN || 'https://api.github.com/orgs/';
+}())
 
 Organization.prototype.getRequestUri = function() {
     return this.BASE_URI + this.organization + '/repos' + '?per_page=' + this.perpage + '&type=' + this.type;

--- a/test/github.js
+++ b/test/github.js
@@ -2,6 +2,19 @@ var should = require('chai').should()
     , sinon = require('sinon')
     , github = require('../lib/github');
 
+
+describe('Organization.prototype.BASE_URI', function() {
+  describe('When the org is hosted on github entriprise', function () {
+    xit('reads the uri from an environment variable', function() {
+      process.env.ENTERPRISE_DOMAIN = 'foobar';
+
+      url = github.Organization.prototype.BASE_URI;
+
+      url.should.equal('foobar');
+    })
+  })
+});
+
 describe('Organization', function() {
     before(function() {
         organization = new github.Organization({


### PR DESCRIPTION
So that this library can be used with GitHub Enterprise,
Organization.prototype.BASE_URI will either read an environment variable
(ENTERPRISE_DOMAIN), or fallback to GitHub's public domain.
