### PR TITLE
Added repo url to clone error logging

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -149,7 +149,7 @@ Organization.prototype.executeCloneCommand = function(repo) {
         if (status == 0) {
             cli.info('success cloning ' + url);
         } else {
-            cli.error('git clone failed with status ' + status);
+            cli.error('git clone failed with status ' + status + ' on ' + url);
         }
     });
 }


### PR DESCRIPTION
Quite often you get "ERROR: git clone failed with status 128" when you run the package. It would be really helpful to see which repository actually failed cloning.
